### PR TITLE
Remove unnecessary imports

### DIFF
--- a/youtubesearchpython/__future__/internal/search.py
+++ b/youtubesearchpython/__future__/internal/search.py
@@ -1,4 +1,3 @@
-from typing import Union
 from youtubesearchpython.__future__.handlers.requesthandler import RequestHandler
 from youtubesearchpython.__future__.handlers.componenthandler import ComponentHandler
 from youtubesearchpython.__future__.internal.constants import *

--- a/youtubesearchpython/handlers/requesthandler.py
+++ b/youtubesearchpython/handlers/requesthandler.py
@@ -1,7 +1,5 @@
-from urllib import request
 from urllib.request import Request, urlopen
 from urllib.parse import urlencode
-import pkg_resources
 import json
 import copy
 from youtubesearchpython.handlers.componenthandler import ComponentHandler

--- a/youtubesearchpython/internal/streamurlfetcher.py
+++ b/youtubesearchpython/internal/streamurlfetcher.py
@@ -1,6 +1,5 @@
 isPyTubeInstalled = False
 
-import httpx
 from urllib.request import urlopen
 from urllib.parse import parse_qs, urlencode
 import json


### PR DESCRIPTION
Hello!
I just removed unnecessary imports that didn't allow me to use this awesome module with an "embeddable" version of Python. It is now completely free of dependencies (`httpx` is only required for the `__future__` submodule).