### PR TITLE
Hotfix for #100

### DIFF
--- a/youtubesearchpython/__future__/internal/extras.py
+++ b/youtubesearchpython/__future__/internal/extras.py
@@ -440,8 +440,5 @@ class HashtagInternal(ComponentHandler):
                     if len(self.resultComponents) >= self.limit:
                         break
                 self.continuationKey = await self._getValue(responseSource[-1], continuationKeyPath)
-            else:
-                # is there any fallback path?
-                raise Exception
         except:
             raise Exception('ERROR: Could not parse YouTube response.')

--- a/youtubesearchpython/internal/extras.py
+++ b/youtubesearchpython/internal/extras.py
@@ -464,9 +464,9 @@ class HashtagInternal(ComponentHandler):
             self.resultComponents = []
             self._makeRequest()
             self._getComponents()
+        if self.resultComponents:
             return True
-        else:
-            return False
+        return False
 
     def _getParams(self) -> None:
         requestBody = copy.deepcopy(requestPayload)
@@ -545,8 +545,5 @@ class HashtagInternal(ComponentHandler):
                     if len(self.resultComponents) >= self.limit:
                         break
                 self.continuationKey = self._getValue(responseSource[-1], continuationKeyPath)
-            else:
-                # is there any fallback path?
-                raise Exception
         except:
             raise Exception('ERROR: Could not parse YouTube response.')


### PR DESCRIPTION
The fact is that usually, if the response contains a `continuationKey`, then there are videos on the next page. But here, for some reason, there may simply be no results on the last page. 