### PR TITLE
Video: Add duration, allowRatings, isLiveContent and isLiveNow

### DIFF
--- a/youtubesearchpython/core/video.py
+++ b/youtubesearchpython/core/video.py
@@ -71,6 +71,9 @@ class VideoCore(RequestCore):
             component = {
                 'id': getValue(self.responseSource, ['videoDetails', 'videoId']),
                 'title': getValue(self.responseSource, ['videoDetails', 'title']),
+                'duration': {
+                    'secondsText': getValue(self.responseSource, ['videoDetails', 'lengthSeconds']),
+                },
                 'viewCount': {
                     'text': getValue(self.responseSource, ['videoDetails', 'viewCount'])
                 },
@@ -80,11 +83,14 @@ class VideoCore(RequestCore):
                     'name': getValue(self.responseSource, ['videoDetails', 'author']),
                     'id': getValue(self.responseSource, ['videoDetails', 'channelId']),
                 },
+                'allowRatings': getValue(self.responseSource, ['videoDetails', 'allowRatings']),
                 'averageRating': getValue(self.responseSource, ['videoDetails', 'averageRating']),
                 'keywords': getValue(self.responseSource, ['videoDetails', 'keywords']),
+                'isLiveContent': getValue(self.responseSource, ['videoDetails', 'isLiveContent']),
                 'publishDate': getValue(self.responseSource, ['microformat', 'playerMicroformatRenderer', 'publishDate']),
                 'uploadDate': getValue(self.responseSource, ['microformat', 'playerMicroformatRenderer', 'uploadDate']),
             }
+            component['isLiveNow'] = component['isLiveContent'] and component['duration']['secondsText'] == "0"
             component['link'] = 'https://www.youtube.com/watch?v=' + component['id']
             component['channel']['link'] = 'https://www.youtube.com/channel/' + component['channel']['id']
             videoComponent.update(component)


### PR DESCRIPTION
- duration, allowRatings and isLiveContent exposure just more data the YouTube backend exposes to the client
- isLiveContent means, that this video __was__ or is live streamed (probably useful for the UI as to know that the chat should be shown and so on)
- isLiveNow is more complex as this property is interfered from duration equals 0 (probably no finite length known for now) and isLiveContent

For testing isLiveNow, I collected some video links and tested if the library works on them. It could be that some live steams will not be live if you want to test this, then use [this generated channel](https://www.youtube.com/channel/UC4R8DWoMoI7CAwX8_LjQHig) to add some current live streams to the test as well.
```python
#!/usr/bin/env python3

import json
import sys

from youtubesearchpython import *


videos = {
    # normal vid
    "https://www.youtube.com/watch?v=Va_Ke6vpjnA": False,
    # stored live stream recordings
    "https://www.youtube.com/watch?v=NH6i057FkLg": False,
    "https://www.youtube.com/watch?v=ohJmVyjJIt4": False,
    # was live while collecting
    "https://www.youtube.com/watch?v=5iqFtm6Y7bE": True,
    "https://www.youtube.com/watch?v=XSxbeNQo9_M": True,
}


for uri, shouldLive in videos.items():
    v = Video.getInfo(uri)
    isLive = v["isLiveNow"]
    if isLive != shouldLive:
        title = v["title"]
        print(f"{title} differs, wasLive: {isLive}, shouldLive: {shouldLive}")
```