### PR TITLE
httpx minimum to 0.14.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'httpx'
+        'httpx>=0.14.2'
     ],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
This library uses `proxies` param with `httpx` get and post methods in these places,

https://github.com/alexmercerind/youtube-search-python/blob/866f120a0ad4f3700ab0a339abfac24ef5b2c592/youtubesearchpython/core/requests.py#L20-L26

https://github.com/alexmercerind/youtube-search-python/blob/866f120a0ad4f3700ab0a339abfac24ef5b2c592/youtubesearchpython/core/requests.py#L34

However, the `httpx` itself got those abilities after the version `0.14.2` (https://github.com/encode/httpx/releases/tag/0.14.2) PR (https://github.com/encode/httpx/pull/1198)

**Exception**

```python
File "/app/.local/python/lib/python3.9/site-packages/youtubesearchpython/core/requests.py", line 20, in syncPostRequest
    return httpx.post(
TypeError: post() got an unexpected keyword argument 'proxies'
```